### PR TITLE
Exemplo de teste de controlador adicionado

### DIFF
--- a/features/browser.feature
+++ b/features/browser.feature
@@ -1,4 +1,4 @@
-Feature: Demonstrate how to test Django with behave & mechanize
+Feature: Demonstrate gui test
 
   Scenario: Logging in to our new Django site
 

--- a/features/login.feature
+++ b/features/login.feature
@@ -1,0 +1,7 @@
+Feature: Demonstrate controller test
+
+  Scenario: Logging in to our new Django site
+
+    Given a user created
+    When I post to /
+    Then I recieve an 302 http status code

--- a/features/steps/login.py
+++ b/features/steps/login.py
@@ -1,0 +1,18 @@
+import string
+from behave import given, when, then
+from django.test import Client, TestCase
+
+@given('a user created')
+def step_impl(context):
+    from custom_user.models import customUser
+    customUser.objects.create_superuser(username='test', email='foo@bar', password='test')
+
+@when('I post to /')
+def step_impl(context):
+    c = Client()
+    response = c.post('/', {'username': 'test', 'password': 'test'})
+    context.response = response
+
+@then('I recieve an 302 http status code')
+def step_impl(context):
+    assert 302 == context.response.status_code


### PR DESCRIPTION
O exemplo de teste de controlador foi adicionado para prover uma padronização entre os integrantes do projeto.